### PR TITLE
Migrate to the Feb 2026 Spotify Web API + reliability fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import './styles/App.scss';
 import i18next from 'i18next';
 import { FC, Suspense, lazy, memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { getFromLocalStorageWithExpiry } from './utils/localstorage';
+import { getRefreshToken } from './utils/spotify/login';
 
 // Components
 import { ConfigProvider } from 'antd';
@@ -79,13 +80,25 @@ const SpotifyContainer: FC<{ children: any }> = memo(({ children }) => {
       playerInitialVolume: 1.0,
       playerRefreshRateMs: 1000,
       playerName: 'Spotify React Player',
-      onPlayerRequestAccessToken: () => Promise.resolve(token!),
+      onPlayerRequestAccessToken: async () => {
+        // Always give the SDK a *fresh* token. Returning the in-memory redux token can hand it
+        // an expired one, which 401s on the SDK's internal `melody/v1/check_scope` call. Prefer
+        // the still-valid stored token; refresh it if it has expired.
+        const stored = getFromLocalStorageWithExpiry('access_token') as string | null;
+        if (stored) return stored;
+        const refreshed = (await getRefreshToken()) as string | null;
+        return refreshed || token || '';
+      },
       onPlayerLoading: () => {},
       onPlayerWaitingForDevice: () => {
         dispatch(authActions.setPlayerLoaded({ playerLoaded: true }));
       },
       onPlayerError: (e) => {
-        dispatch(loginToSpotify());
+        // Don't re-login on every player error. Non-Premium accounts emit `account_error`
+        // ("premium required") and failed transfers emit errors on each attempt — calling
+        // loginToSpotify() here caused an endless re-login loop. Just surface it; token
+        // refresh is handled by the axios 401 interceptor + onPlayerRequestAccessToken.
+        console.warn('Spotify player error:', e);
       },
       onPlayerDeviceSelected: () => {
         dispatch(authActions.setPlayerLoaded({ playerLoaded: true }));

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -1,6 +1,7 @@
 import Axios from 'axios';
 import { getRefreshToken } from './utils/spotify/login';
 import { getFromLocalStorageWithExpiry } from './utils/localstorage';
+import { cacheGet, cacheSet } from './utils/cache';
 
 const path = 'https://api.spotify.com/v1' as const;
 
@@ -42,14 +43,54 @@ const releaseSlot = () => {
   waiters.shift()?.();
 };
 
+// --- IndexedDB response cache ----------------------------------------------------------------
+// Catalog data (artists/albums/tracks) is immutable, so cache GETs of it in IndexedDB and serve
+// from there on repeat views and across reloads. This is the real fix for the rate limiting:
+// navigating back to a page, or hard-refreshing, no longer re-hits the network. Only static
+// catalog GETs are cached — user state (/me/*), search, and all mutations always hit the API.
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // catalog is static; 24h is safe
+const CACHEABLE_PATH = /^\/(artists|albums|tracks)(\/|$)/;
+
+const isCacheableGet = (config: any) =>
+  (config.method || 'get').toLowerCase() === 'get' && CACHEABLE_PATH.test(config.url || '');
+
+const cacheKeyFor = (config: any) =>
+  `${config.url}?${JSON.stringify(config.params || {})}`;
+
 axios.interceptors.request.use(async (config) => {
   await acquireSlot();
+
+  if (isCacheableGet(config)) {
+    const key = cacheKeyFor(config);
+    const entry = await cacheGet(key);
+    if (entry && entry.expiry > Date.now()) {
+      // Cache hit — short-circuit the network by serving from a one-off adapter. The response
+      // still flows through the response interceptor below (so the slot is released normally).
+      (config as any).adapter = async () => ({
+        data: entry.data,
+        status: 200,
+        statusText: 'OK (cache)',
+        headers: {},
+        config,
+        request: {},
+      });
+    } else {
+      // Mark for storing once the network response comes back.
+      (config as any).__cacheKey = key;
+    }
+  }
+
   return config;
 });
 
 axios.interceptors.response.use(
   (response) => {
     releaseSlot();
+
+    const key = (response.config as any).__cacheKey;
+    if (key && response.status === 200) {
+      void cacheSet(key, { data: response.data, expiry: Date.now() + CACHE_TTL_MS });
+    }
     return response;
   },
   async (error) => {

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -15,22 +15,81 @@ if (access_token) {
   axios.defaults.headers.common['Authorization'] = 'Bearer ' + access_token;
 }
 
+// --- Global concurrency limiter --------------------------------------------------------------
+// Several screens (Home, Artist) fan out many requests at once, and dev StrictMode doubles
+// them. Spotify's tightened Feb-2026 rate limits 429 on those bursts. Cap how many requests are
+// in flight at once so traffic is smoothed instead of bursted; the rest queue and drain as
+// slots free up. Combined with the 429 backoff below, this keeps the app under the limit.
+const MAX_CONCURRENT = 3;
+let activeRequests = 0;
+const waiters: Array<() => void> = [];
+
+const acquireSlot = () =>
+  new Promise<void>((resolve) => {
+    if (activeRequests < MAX_CONCURRENT) {
+      activeRequests++;
+      resolve();
+    } else {
+      waiters.push(() => {
+        activeRequests++;
+        resolve();
+      });
+    }
+  });
+
+const releaseSlot = () => {
+  activeRequests = Math.max(0, activeRequests - 1);
+  waiters.shift()?.();
+};
+
+axios.interceptors.request.use(async (config) => {
+  await acquireSlot();
+  return config;
+});
+
 axios.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response.status === 401) {
+  (response) => {
+    releaseSlot();
+    return response;
+  },
+  async (error) => {
+    // Release this attempt's slot first so a retry (and other queued requests) can proceed.
+    releaseSlot();
+
+    const response = error?.response;
+    const config = error?.config;
+
+    // Network error / no response — nothing to recover from.
+    if (!response || !config) return Promise.reject(error);
+
+    if (response.status === 401) {
       return getRefreshToken()
         .then((token) => {
           if (!token) return Promise.reject(error);
           axios.defaults.headers.common['Authorization'] = 'Bearer ' + token;
-          error.config.headers['Authorization'] = 'Bearer ' + token;
-          return axios(error.config);
+          config.headers['Authorization'] = 'Bearer ' + token;
+          return axios(config);
         })
         .catch(() => {
           localStorage.removeItem('refresh_token');
           localStorage.removeItem('access_token');
         });
     }
+
+    // 429 Too Many Requests: Spotify's tightened (Feb 2026) rate limits are easy to trip when
+    // a page fires a burst of calls (and dev StrictMode doubles them). Back off for the
+    // server-specified `Retry-After`, then retry — bounded so we never loop forever.
+    if (response.status === 429) {
+      config.__retryCount = (config.__retryCount || 0) + 1;
+      // Only one retry: during a global cooldown, re-issuing many times just adds load and
+      // prolongs the penalty window.
+      if (config.__retryCount > 1) return Promise.reject(error);
+      const retryAfter = Number(response.headers?.['retry-after']);
+      const waitMs = Math.min((Number.isFinite(retryAfter) ? retryAfter : 1) * 1000, 10000);
+      await new Promise((resolve) => setTimeout(resolve, Math.max(waitMs, 500)));
+      return axios(config);
+    }
+
     return Promise.reject(error);
   }
 );

--- a/src/components/Layout/components/NowPlaying/Details/artist.tsx
+++ b/src/components/Layout/components/NowPlaying/Details/artist.tsx
@@ -19,7 +19,7 @@ export const Artist: FC = () => {
           image={artist.images[0].url}
           imageTitle={t('About the artist')}
           extra={<FollowArtistButton id={artist.id} />}
-          subtitle={`${artist.followers.total} ${t('followers')}`}
+          subtitle={`${artist.followers?.total ?? 0} ${t('followers')}`}
         />
       </div>
     </ArtistActionsWrapper>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
@@ -15,11 +14,11 @@ TimeAgo.addDefaultLocale(en);
 TimeAgo.addLocale(es);
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+// NOTE: StrictMode is intentionally disabled. In dev it double-invokes every effect, which
+// fires every Spotify API request twice and was a major contributor to hitting Spotify's
+// (tightened, Feb-2026) rate limits — half the calls on the Home/Artist/Album pages were
+// duplicates. Re-enable (<React.StrictMode>) if you need its checks and can tolerate 2x calls.
+root.render(<App />);
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))

--- a/src/pages/Artist/components/otherArtists/index.tsx
+++ b/src/pages/Artist/components/otherArtists/index.tsx
@@ -13,6 +13,12 @@ export const OtherArtists = memo(() => {
   const [t] = useTranslation(['artist']);
   const artists = useAppSelector((state) => state.artist.otherArtists);
 
+  // Related artists were removed from the Spotify API (no replacement), so this is always
+  // empty now — hide the section instead of rendering a bare "Fans also like" header.
+  if (!artists.length) {
+    return null;
+  }
+
   return (
     <div>
       <div>

--- a/src/pages/Artist/container/header.tsx
+++ b/src/pages/Artist/container/header.tsx
@@ -84,7 +84,7 @@ export const ArtistHeader: FC<{
               <h1>{artist?.name}</h1>
             </span>
             <span className='listeners'>
-              {artist?.followers.total} {t('followers')}
+              {artist?.followers?.total ?? 0} {t('followers')}
             </span>
           </div>
         </div>

--- a/src/services/albums.ts
+++ b/src/services/albums.ts
@@ -4,8 +4,13 @@ import type { Track } from '../interfaces/track';
 import type { Album, AlbumFullObject } from '../interfaces/albums';
 import type { Pagination, PaginationQueryParams } from '../interfaces/api';
 
-const fetchNewRelases = (params: PaginationQueryParams = {}) =>
-  axios.get<{ albums: Pagination<Album> }>('/browse/new-releases', { params });
+const fetchNewRelases = async (_params: PaginationQueryParams = {}) => {
+  // `/browse/new-releases` was removed (Nov 2024 / Feb 2026). The previous approximation
+  // (latest albums from each followed artist) fired ~7 requests on every Home load, which was
+  // a major contributor to hitting Spotify's rate limit. Return empty so the "New releases"
+  // row hides cleanly and Home stays cheap; the user's other personalized rows still populate.
+  return { data: { albums: { items: [] } as unknown as Pagination<Album> } };
+};
 
 /**
  * @description Get Spotify catalog information for a single album.
@@ -15,8 +20,11 @@ const fetchAlbum = (id: string) => axios.get<AlbumFullObject>(`/albums/${id}`);
 /**
  * @description Get Spotify catalog information for multiple albums identified by their Spotify IDs.
  */
-const fetchAlbums = (ids: string[]) =>
-  axios.get<{ albums: Album[] }>(`/albums`, { params: { ids: ids.join(',') } });
+const fetchAlbums = async (ids: string[]) => {
+  // Feb 2026 removed the batch `/albums?ids=` endpoint; fetch each album individually.
+  const responses = await Promise.all(ids.map((id) => axios.get<Album>(`/albums/${id}`)));
+  return { ...responses[0], data: { albums: responses.map((r) => r.data) } };
+};
 
 /**
  * @description Get Spotify catalog information about an album’s tracks. Optional parameters can be used to limit the number of tracks returned.
@@ -33,12 +41,14 @@ const fetchSavedAlbums = (params: PaginationQueryParams = {}) =>
 /**
  * @description Save one or more albums to the current user's 'Your Music' library.
  */
-const saveAlbums = (ids: string[]) => axios.put('/me/albums', { ids });
+const saveAlbums = (ids: string[]) =>
+  axios.put('/me/library', { uris: ids.map((id) => `spotify:album:${id}`) });
 
 /**
  * @description Remove one or more albums from the current user's 'Your Music' library.
  */
-const deleteAlbums = (ids: string[]) => axios.delete('/me/albums', { data: { ids } });
+const deleteAlbums = (ids: string[]) =>
+  axios.delete('/me/library', { data: { uris: ids.map((id) => `spotify:album:${id}`) } });
 
 export const albumsService = {
   fetchAlbum,

--- a/src/services/artist.ts
+++ b/src/services/artist.ts
@@ -13,8 +13,11 @@ const fetchArtist = (id: string) => axios.get<Artist>(`/artists/${id}`);
 /**
  * @description Get Spotify catalog information for several artists based on their Spotify IDs.
  */
-const fetchArtists = (ids: string[]) =>
-  axios.get<{ artists: Artist[] }>(`/artists`, { params: { ids: ids.join(',') } });
+const fetchArtists = async (ids: string[]) => {
+  // Feb 2026 removed the batch `/artists?ids=` endpoint; fetch each artist individually.
+  const responses = await Promise.all(ids.map((id) => axios.get<Artist>(`/artists/${id}`)));
+  return { ...responses[0], data: { artists: responses.map((r) => r.data) } };
+};
 
 /**
  * @description Get Spotify catalog information about an artist's albums.
@@ -36,14 +39,22 @@ const fetchArtistAlbums = (
 /**
  * @description Get Spotify catalog information about an artist's top tracks by country.
  */
-const fetchArtistTopTracks = (id: string) =>
-  axios.get<{ tracks: Track }>(`/artists/${id}/top-tracks`);
+const fetchArtistTopTracks = async (_id: string) => {
+  // `/artists/{id}/top-tracks` was removed (Nov 2024 / Feb 2026) with no replacement. The
+  // previous approximation cost 2 extra requests per artist load, which contributed to
+  // Spotify rate-limiting the account. Return empty so the "Popular" section hides and the
+  // artist page stays cheap (the album/single sections still render).
+  return { data: { tracks: [] as Track[] } };
+};
 
 /**
  * @description Get Spotify catalog information about artists similar to a given artist. Similarity is based on analysis of the Spotify community's listening history.
  */
-const fetchSimilarArtists = (id: string) =>
-  axios.get<{ artists: Artist[] }>(`/artists/${id}/related-artists`);
+const fetchSimilarArtists = async (_id: string) => {
+  // `/artists/{id}/related-artists` was removed with no first-party replacement. Return
+  // empty so the Artist page's "Fans also like" section hides cleanly.
+  return { data: { artists: [] as Artist[] } };
+};
 
 export const artistService = {
   fetchArtist,

--- a/src/services/categories.ts
+++ b/src/services/categories.ts
@@ -4,25 +4,33 @@ import type { Playlist } from '../interfaces/playlists';
 import type { Category } from '../interfaces/categories';
 import type { Pagination, PaginationQueryParams } from '../interfaces/api';
 
-/**
- * @description Get a list of categories used to tag items in Spotify (on, for example, the Spotify player’s “Browse” tab).
- */
-const fetchCategories = (params: PaginationQueryParams = {}) =>
-  axios.get<{ categories: Pagination<Category> }>('/browse/categories', { params });
+// The `/browse/*` family (categories, category playlists, single category) was removed in
+// Nov 2024 / Feb 2026 with no replacement. These return empty results so the Browse page and
+// the category-backed Home rows (Made For You / Rankings / Trending) hide cleanly instead of
+// throwing 404s. Callers' response shapes are preserved.
+const emptyPage = <T>() =>
+  ({ items: [], total: 0, limit: 0, offset: 0, next: null, previous: null } as unknown as Pagination<T>);
 
 /**
- * @description Get a list of Spotify playlists tagged with a particular category.
+ * @description (Removed by Spotify.) Previously: list of browse categories.
  */
-const fetchCategoryPlaylists = (categoryId: string, params: PaginationQueryParams = {}) =>
-  axios.get<{ playlists: Pagination<Playlist> }>(`/browse/categories/${categoryId}/playlists`, {
-    params,
-  });
+const fetchCategories = async (_params: PaginationQueryParams = {}) => {
+  return { data: { categories: emptyPage<Category>() } };
+};
 
 /**
- * @description Get a single category used to tag items in Spotify (on, for example, the Spotify player’s “Browse” tab).
+ * @description (Removed by Spotify.) Previously: playlists tagged with a category.
  */
-const fetchCategory = (categoryId: string) =>
-  axios.get<Category>(`/browse/categories/${categoryId}`);
+const fetchCategoryPlaylists = async (_categoryId: string, _params: PaginationQueryParams = {}) => {
+  return { data: { playlists: emptyPage<Playlist>() } };
+};
+
+/**
+ * @description (Removed by Spotify.) Previously: a single browse category.
+ */
+const fetchCategory = async (_categoryId: string) => {
+  return { data: null as unknown as Category };
+};
 
 export const categoriesService = {
   fetchCategories,

--- a/src/services/episodes.ts
+++ b/src/services/episodes.ts
@@ -4,7 +4,7 @@ import axios from '../axios';
  * @description Save one or more episodes to the current user's library.
  */
 const saveEpisodes = (ids: string[]) =>
-  axios.put('/me/episodes', null, { params: { ids: ids.join(',') } });
+  axios.put('/me/library', { uris: ids.map((id) => `spotify:episode:${id}`) });
 
 export const episodesService = {
   saveEpisodes,

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -3,6 +3,63 @@ import type { Pagination } from '../interfaces/api';
 import { Device } from '../interfaces/devices';
 import type { PlayHistoryObject } from '../interfaces/player';
 
+// The device playback commands should target — the Web Playback SDK device by default, or
+// whatever device the user explicitly transfers to. Sending `device_id` on `play` means we
+// don't depend on Spotify already having an "active device", which avoids the 404
+// "Device not found" (its message for "no active device" too). Persist to localStorage so the
+// id survives dev-server hot-reloads, where the SDK's `ready` event won't fire again.
+const DEVICE_STORAGE_KEY = 'playback_device_id';
+let playbackDeviceId: string | null = null;
+// Name of our Web Playback SDK device, used to re-resolve its id from the live devices list.
+// The SDK assigns a NEW device_id on every (re)connect, so a cached id goes stale — matching
+// by name is the reliable way to find the current device.
+let playbackDeviceName: string | null = null;
+
+export const setPlaybackDevice = (deviceId: string | null) => {
+  playbackDeviceId = deviceId;
+  try {
+    if (deviceId) localStorage.setItem(DEVICE_STORAGE_KEY, deviceId);
+  } catch {
+    /* ignore storage errors */
+  }
+};
+
+export const setPlaybackDeviceName = (name: string | null) => {
+  playbackDeviceName = name;
+};
+
+const currentDeviceId = () => {
+  if (playbackDeviceId) return playbackDeviceId;
+  try {
+    return localStorage.getItem(DEVICE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+const deviceParams = () => {
+  const id = currentDeviceId();
+  return id ? { device_id: id } : undefined;
+};
+
+// Resolve the current, live id of our SDK device from `/me/player/devices`, matching by name
+// (falling back to the cached id). Updates the cache so subsequent calls hit the fast path.
+const resolveLiveDeviceId = async (): Promise<string | null> => {
+  try {
+    const { data } = await axios.get<{ devices: Device[] }>('/me/player/devices');
+    const match =
+      (playbackDeviceName && data.devices.find((d) => d.name === playbackDeviceName)) ||
+      data.devices.find((d) => d.id === currentDeviceId());
+    if (match?.id) {
+      setPlaybackDevice(match.id);
+      return match.id;
+    }
+  } catch {
+    /* ignore — fall back to the cached id below */
+  }
+  return currentDeviceId();
+};
+
 /**
  * @description Get information about the user’s current playback state, including track or episode, progress, and active device.
  */
@@ -17,6 +74,9 @@ const fetchPlaybackState = async () => {
  * @param deviceId The ID of the device this command is targeting. If not supplied, the user’s currently active device is the target.
  */
 const transferPlayback = async (deviceId: string) => {
+  // Remember the target before the request: even if this transfer 404s due to the
+  // registration race, subsequent `startPlayback` calls carry `device_id` and recover.
+  setPlaybackDevice(deviceId);
   await axios.put('/me/player', { device_ids: [deviceId] });
 };
 
@@ -34,65 +94,92 @@ const getAvailableDevices = async () => {
 const startPlayback = async (
   body: { context_uri?: string; uris?: string[]; offset?: { position: number } } = {}
 ) => {
-  await axios.put('/me/player/play', body);
+  try {
+    await axios.put('/me/player/play', body, { params: deviceParams() });
+  } catch (e: any) {
+    // "Device not found" means the cached id is stale (the SDK reconnected with a new id) or
+    // our device isn't active yet. Re-resolve the live device by name, transfer, and retry.
+    if (e?.response?.status !== 404) throw e;
+    const id = await resolveLiveDeviceId();
+    if (!id) throw e;
+    await axios.put('/me/player', { device_ids: [id] }).catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    await axios.put('/me/player/play', body, { params: { device_id: id } });
+  }
+};
+
+// Fire-and-forget transport command. Targets our SDK device (so it doesn't depend on a
+// pre-existing "active device") and never throws on a transient failure — e.g. a stray
+// `onChangeEnd` fired during a React StrictMode unmount, or no active device yet. This keeps a
+// failed control call from surfacing as an uncaught 404 in the UI.
+const playerCommand = async (
+  method: 'put' | 'post',
+  url: string,
+  params?: Record<string, string | number | boolean>
+) => {
+  try {
+    await axios[method](url, {}, { params: { ...deviceParams(), ...params } });
+  } catch (e) {
+    console.warn(`Spotify player command failed: ${method.toUpperCase()} ${url}`, e);
+  }
 };
 
 /**
- * @description Pause playback on the user's account. This API only works for users who have Spotify Premium. The order of execution is not guaranteed when you use this API with other Player API endpoints.
+ * @description Pause playback on the user's account. This API only works for users who have Spotify Premium.
  */
 const pausePlayback = async () => {
-  await axios.put('/me/player/pause');
+  await playerCommand('put', '/me/player/pause');
 };
 
 /**
- * @description Skip to the next track in the user’s queue. This API only works for users who have Spotify Premium. The order of execution is not guaranteed when you use this API with other Player API endpoints.
+ * @description Skip to the next track in the user’s queue. This API only works for users who have Spotify Premium.
  */
 const nextTrack = async () => {
-  await axios.post('/me/player/next');
+  await playerCommand('post', '/me/player/next');
 };
 
 /**
- * @description Skip to the previous track in the user’s queue. This API only works for users who have Spotify Premium. The order of execution is not guaranteed when you use this API with other Player API endpoints.
+ * @description Skip to the previous track in the user’s queue. This API only works for users who have Spotify Premium.
  */
 const previousTrack = async () => {
-  await axios.post('/me/player/previous');
+  await playerCommand('post', '/me/player/previous');
 };
 
 /**
- * @description Seeks to the given position in the user’s currently playing track. This API only works for users who have Spotify Premium. The order of execution is not guaranteed when you use this API with other Player API endpoints.
+ * @description Seeks to the given position in the user’s currently playing track. This API only works for users who have Spotify Premium.
  */
 const seekToPosition = async (position_ms: number) => {
-  await axios.put('/me/player/seek', {}, { params: { position_ms } });
+  await playerCommand('put', '/me/player/seek', { position_ms });
 };
 
 /**
- * @description Set the repeat mode for the user's playback. This API only works for users who have Spotify Premium. The order of execution is not guaranteed when you use this API with other Player API endpoints.
+ * @description Set the repeat mode for the user's playback. This API only works for users who have Spotify Premium.
  * @param state track, context, or off. track will repeat the current track. context will repeat the current context. off will turn repeat off.
  */
 const setRepeatMode = async (state: 'track' | 'context' | 'off') => {
-  await axios.put('/me/player/repeat', {}, { params: { state } });
+  await playerCommand('put', '/me/player/repeat', { state });
 };
 
 /**
- * @description Set the volume for the user’s current playback device. This API only works for users who have Spotify Premium. The order of execution is not guaranteed when you use this API with other Player API endpoints.
+ * @description Set the volume for the user’s current playback device. This API only works for users who have Spotify Premium.
  * @param volume_percent The volume to set. Must be a value from 0 to 100 inclusive.
  */
 const setVolume = async (volume_percent: number) => {
-  await axios.put('/me/player/volume', {}, { params: { volume_percent } });
+  await playerCommand('put', '/me/player/volume', { volume_percent });
 };
 
 /**
- * @description Toggle shuffle on or off for user’s playback. This API only works for users who have Spotify Premium. The order of execution is not guaranteed when you use this API with other Player API endpoints.
+ * @description Toggle shuffle on or off for user’s playback. This API only works for users who have Spotify Premium.
  */
 const toggleShuffle = async (state: boolean) => {
-  await axios.put('/me/player/shuffle', {}, { params: { state } });
+  await playerCommand('put', '/me/player/shuffle', { state });
 };
 
 /**
- * @description Add an item to the end of the user's current playback queue. This API only works for users who have Spotify Premium. The order of execution is not guaranteed when you use this API with other Player API endpoints.
+ * @description Add an item to the end of the user's current playback queue. This API only works for users who have Spotify Premium.
  */
 const addToQueue = async (uri: string) => {
-  await axios.post('/me/player/queue', {}, { params: { uri } });
+  await playerCommand('post', '/me/player/queue', { uri });
 };
 
 /**
@@ -107,6 +194,8 @@ const getRecentlyPlayed = async (params: { limit?: number; after?: number; befor
 
 export const playerService = {
   addToQueue,
+  setPlaybackDevice,
+  setPlaybackDeviceName,
   fetchPlaybackState,
   transferPlayback,
   startPlayback,

--- a/src/services/playlists.ts
+++ b/src/services/playlists.ts
@@ -10,7 +10,12 @@ import type { Pagination, PaginationQueryParams } from '../interfaces/api';
  * @param playlistId The Spotify ID for the playlist.
  */
 const getPlaylist = async (playlistId: string) => {
-  return axios.get<Playlist>(`/playlists/${playlistId}`);
+  const response = await axios.get<Playlist>(`/playlists/${playlistId}`);
+  // Feb 2026 may expose the playlist's track collection as `items` instead of `tracks`.
+  // Normalize to `tracks` so the header/table (which read `playlist.tracks.total`) are unchanged.
+  const data = response.data as unknown as Record<string, any>;
+  if (data && !data.tracks && data.items) data.tracks = data.items;
+  return response;
 };
 
 interface GetPlaylistItemsParams extends PaginationQueryParams {
@@ -24,7 +29,17 @@ const getPlaylistItems = async (
   playlistId: string,
   params: GetPlaylistItemsParams = { limit: 50 }
 ) => {
-  return axios.get<Pagination<PlaylistItem>>(`/playlists/${playlistId}/tracks`, { params });
+  const response = await axios.get<Pagination<PlaylistItem>>(`/playlists/${playlistId}/items`, {
+    params,
+  });
+  // Feb 2026 renamed `/tracks` → `/items` and each entry's `track` field → `item`.
+  // Remap back to the legacy `{ ...entry, track }` shape so the Redux slice and the
+  // track table (which read `item.track`) stay untouched.
+  const items = response.data?.items as unknown as Array<Record<string, any>> | undefined;
+  items?.forEach((entry) => {
+    if (entry && entry.item && !entry.track) entry.track = entry.item;
+  });
+  return response;
 };
 
 /**
@@ -41,15 +56,26 @@ interface GetFeaturedPlaylistsParams extends PaginationQueryParams {
 /**
  * @description Get a list of Spotify featured playlists (shown, for example, on a Spotify player's 'Browse' tab).
  */
-const getFeaturedPlaylists = async (params: GetFeaturedPlaylistsParams = {}) => {
-  return axios.get<{ playlists: Pagination<Playlist> }>('/browse/featured-playlists', { params });
+const getFeaturedPlaylists = async (_params: GetFeaturedPlaylistsParams = {}) => {
+  // `/browse/featured-playlists` was removed (Nov 2024 / Feb 2026) with no replacement.
+  // Return empty so the Home "Featured playlists" row hides cleanly (the component renders
+  // null on an empty list); the user's own playlists still appear via their dedicated row.
+  const empty = {
+    items: [],
+    total: 0,
+    limit: 0,
+    offset: 0,
+    next: null,
+    previous: null,
+  } as unknown as Pagination<Playlist>;
+  return { data: { playlists: empty } };
 };
 
 /**
  * @description Add one or more items to a user's playlist.
  */
 const addPlaylistItems = async (playlistId: string, uris: string[], snapshot_id: string) => {
-  return axios.post(`/playlists/${playlistId}/tracks`, {
+  return axios.post(`/playlists/${playlistId}/items`, {
     uris,
     snapshot_id,
   });
@@ -59,9 +85,9 @@ const addPlaylistItems = async (playlistId: string, uris: string[], snapshot_id:
  * @description Remove one or more items from a user's playlist.
  */
 const removePlaylistItems = async (playlistId: string, uris: string[], snapshot_id: string) => {
-  return axios.delete(`/playlists/${playlistId}/tracks`, {
+  return axios.delete(`/playlists/${playlistId}/items`, {
     data: {
-      tracks: uris.map((uri) => ({ uri })),
+      items: uris.map((uri) => ({ uri })),
       snapshot_id,
     },
   });
@@ -79,7 +105,7 @@ const reorderPlaylistItems = async (
   snapshotId: string
 ) => {
   return axios.put(
-    `/playlists/${playlistId}/tracks`,
+    `/playlists/${playlistId}/items`,
     {
       range_start: rangeStart,
       insert_before: insertBefore,
@@ -127,7 +153,8 @@ const createPlaylist = async (
     description?: string;
   }
 ) => {
-  return axios.post<Playlist>(`/users/${userId}/playlists`, data);
+  // Feb 2026 removed `POST /users/{id}/playlists`; only the current user's `/me/playlists` works.
+  return axios.post<Playlist>(`/me/playlists`, data);
 };
 
 /**
@@ -139,20 +166,28 @@ const getRecommendations = async (params: {
   limit?: number;
   seed_tracks?: string;
 }) => {
-  return axios.get<{ tracks: Track[] }>('/recommendations', { params });
+  // `/recommendations` was removed (Nov 2024 / Feb 2026) with no public replacement.
+  // Repurpose with the user's short-term top tracks so the "recommended" row stays
+  // populated. Seeds are ignored; the response is reshaped to the legacy `{ tracks }`.
+  const response = await axios.get<Pagination<Track>>('/me/top/tracks', {
+    params: { limit: params.limit ?? 25, time_range: 'short_term' },
+  });
+  return { ...response, data: { tracks: response.data.items } };
 };
 
 /**
  * @description Get a list of the playlists owned or followed by a Spotify user.
  */
 const getPlaylists = async (
-  userId: string,
+  _userId: string,
   params: {
     limit?: number;
     offset?: number;
   }
 ) => {
-  return axios.get<Pagination<Playlist>>(`/users/${userId}/playlists`, { params });
+  // Feb 2026 removed `/users/{id}/playlists` (other users). Only the current user's
+  // playlists are available now, so this returns `/me/playlists` regardless of `_userId`.
+  return axios.get<Pagination<Playlist>>(`/me/playlists`, { params });
 };
 
 export const playlistService = {

--- a/src/services/search.ts
+++ b/src/services/search.ts
@@ -7,6 +7,11 @@ import type { Pagination } from '../interfaces/api';
 import type { Playlist } from '../interfaces/playlists';
 import type { Episode } from '../interfaces/episode';
 
+// Feb 2026 reduced `/search`'s max `limit` from 50 to 10. Clamp here so every caller is safe
+// without having to audit each call site; pagination via `offset` still fetches more.
+const SEARCH_MAX_LIMIT = 10;
+const clampLimit = (limit?: number) => Math.min(limit ?? SEARCH_MAX_LIMIT, SEARCH_MAX_LIMIT);
+
 /**
  * @description Get Spotify catalog information about albums, artists, playlists, tracks, shows, episodes or audiobooks that match a keyword string. Audiobooks are only available within the US, UK, Canada, Ireland, New Zealand and Australia markets.
  */
@@ -37,7 +42,7 @@ export const querySearch = (params: {
     tracks: Pagination<Track>;
     artists: Pagination<Artist>;
     playlists: Pagination<Playlist>;
-  }>(`/search`, { params });
+  }>(`/search`, { params: { ...params, limit: clampLimit(params.limit) } });
 
 /**
  * @description Search podcast episodes by keyword (`GET /search?type=episode`).
@@ -49,5 +54,5 @@ export const searchEpisodes = (params: {
   market?: string;
 }) =>
   axios.get<{ episodes: Pagination<Episode> }>('/search', {
-    params: { ...params, type: 'episode' },
+    params: { ...params, type: 'episode', limit: clampLimit(params.limit) },
   });

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -12,6 +12,21 @@ interface FetchTopItemsParams extends PaginationQueryParams {
   timeRange: 'long_term' | 'medium_term' | 'short_term';
 }
 
+// --- Feb 2026 library consolidation -----------------------------------------
+// Per-type save/remove/follow + their `/contains` checks were replaced by a single
+// `/me/library` surface keyed by Spotify URIs. These helpers let the existing
+// id-based service functions keep their signatures while talking to the new API.
+type LibraryType = 'track' | 'album' | 'artist' | 'playlist' | 'user' | 'episode';
+
+const toUris = (ids: string[], type: LibraryType) => ids.map((id) => `spotify:${type}:${id}`);
+
+const saveToLibrary = (uris: string[]) => axios.put('/me/library', { uris });
+
+const removeFromLibrary = (uris: string[]) => axios.delete('/me/library', { data: { uris } });
+
+const libraryContains = (uris: string[]) =>
+  axios.get<boolean[]>('/me/library/contains', { params: { uris: uris.join(',') } });
+
 /**
  * @description Get the current user's top  tracks based on calculated affinity.
  */
@@ -48,14 +63,14 @@ const fetchQueue = async () => {
  * @description Check if one or more tracks is already saved in the current Spotify user's 'Your Music' library.
  */
 const checkSavedTracks = async (ids: string[]) => {
-  return await axios.get<boolean[]>('/me/tracks/contains', { params: { ids: ids.join(',') } });
+  return await libraryContains(toUris(ids, 'track'));
 };
 
 /**
  * @description Save one or more tracks to the current user's 'Your Music' library.
  */
 const saveTracks = async (ids: string[]) => {
-  return await axios.put('/me/tracks', { ids });
+  return await saveToLibrary(toUris(ids, 'track'));
 };
 
 /**
@@ -63,14 +78,14 @@ const saveTracks = async (ids: string[]) => {
  * @param ids An array of the Spotify IDs of the tracks. A maximum of 50 IDs can be sent in one request.
  */
 const deleteTracks = async (ids: string[]) => {
-  return await axios.delete('/me/tracks', { data: { ids } });
+  return await removeFromLibrary(toUris(ids, 'track'));
 };
 
 /**
  * @description Check to see if the current user is following a specified playlist.
  */
 const checkFollowedPlaylist = async (playlistId: string) => {
-  return await axios.get<boolean[]>(`/playlists/${playlistId}/followers/contains`).catch(() => {
+  return await libraryContains(toUris([playlistId], 'playlist')).catch(() => {
     return { data: false };
   });
 };
@@ -79,67 +94,68 @@ const checkFollowedPlaylist = async (playlistId: string) => {
  * @description Check to see if the current user is following one or more artists or other Spotify users.
  */
 const checkFollowingArtists = async (ids: string[]) => {
-  return await axios.get<boolean[]>('/me/following/contains', {
-    params: { type: 'artist', ids: ids.join(',') },
-  });
+  return await libraryContains(toUris(ids, 'artist'));
 };
 
 /**
  * @description Check to see if the current user is following one or more other Spotify users.
  */
 const checkFollowingUsers = async (ids: string[]) => {
-  return await axios.get<boolean[]>('/me/following/contains', {
-    params: { type: 'user', ids: ids.join(',') },
-  });
+  return await libraryContains(toUris(ids, 'user'));
 };
 
 /**
  * @description Get public profile information about a Spotify user.
  */
 const getUser = async (id: string) => {
-  return await axios.get<User>(`/users/${id}`);
+  // `/users/{id}` was removed Feb 2026 (only `/me` survives). Fail soft so callers such as
+  // the playlist owner lookup don't reject their `Promise.all` — they fall back to the
+  // playlist's embedded `owner` object instead.
+  return await axios
+    .get<User>(`/users/${id}`)
+    .catch(() => ({ data: null as unknown as User }));
 };
 
 /**
  * @description Remove the current user as a follower of a playlist.
  */
 const unfollowPlaylist = async (playlistId: string) => {
-  return await axios.delete(`/playlists/${playlistId}/followers`);
+  return await removeFromLibrary(toUris([playlistId], 'playlist'));
 };
 
 /**
  * @description Add the current user as a follower of a playlist.
  */
 const followPlaylist = async (playlistId: string) => {
-  return await axios.put(`/playlists/${playlistId}/followers`);
+  return await saveToLibrary(toUris([playlistId], 'playlist'));
 };
 
 /**
  * @description Add the current user as a follower of one or more artists or other Spotify users.
  */
 const followArtists = async (ids: string[]) => {
-  return await axios.put('/me/following', { type: 'artist', ids });
+  return await saveToLibrary(toUris(ids, 'artist'));
 };
 
 /**
  * @description Remove the current user as a follower of one or more artists or other Spotify users.
  */
 const unfollowArtists = async (ids: string[]) => {
-  return await axios.delete('/me/following', { params: { type: 'artist', ids: ids.join(',') } });
+  return await removeFromLibrary(toUris(ids, 'artist'));
 };
 
 /**
  * @description Add the current user as a follower of one or more users or other Spotify users.
  */
 const followUsers = async (ids: string[]) => {
-  return await axios.put('/me/following', { type: 'user', ids });
+  return await saveToLibrary(toUris(ids, 'user'));
 };
 
 /**
  * @description Remove the current user as a follower of one or more other Spotify users.
  */
 const unfollowUsers = async (ids: string[]) => {
-  return await axios.delete('/me/following', { params: { type: 'user', ids: ids.join(',') } });
+  return await removeFromLibrary(toUris(ids, 'user'));
 };
 
 /**

--- a/src/store/slices/artist.ts
+++ b/src/store/slices/artist.ts
@@ -47,10 +47,14 @@ export const fetchArtist = createAsyncThunk<[Artist, boolean, TrackWithSave[], A
       artistService.fetchArtist(id),
       user ? userService.checkFollowingArtists([id]) : Promise.resolve({ data: [false] }),
       artistService.fetchArtistTopTracks(id),
-      artistService.fetchArtistAlbums(id, { limit: 10, include_groups: 'album' }),
-      artistService.fetchArtistAlbums(id, { limit: 10, include_groups: 'single' }),
-      artistService.fetchArtistAlbums(id, { limit: 10, include_groups: 'appears_on' }),
-      artistService.fetchArtistAlbums(id, { limit: 10, include_groups: 'compilation' }),
+      // One combined album request instead of four (one per include_group), to stay under
+      // Spotify's tightened rate limit. We partition client-side by `album_type`. Note
+      // `appears_on` can no longer be distinguished (the `album_group` field was removed in
+      // Feb 2026), so that section stays empty and hides.
+      artistService.fetchArtistAlbums(id, {
+        limit: 50,
+        include_groups: 'album,single,appears_on,compilation' as any,
+      }),
     ];
 
     const responses = await Promise.all(promises);
@@ -59,14 +63,17 @@ export const fetchArtist = createAsyncThunk<[Artist, boolean, TrackWithSave[], A
     const [following] = responses[1].data as boolean[];
 
     const tracks = (responses[2].data as any).tracks as Track[];
-    const albums = (responses[3].data as Pagination<Album>).items as Album[];
-    const singles = (responses[4].data as Pagination<Album>).items as Album[];
 
-    const appearsOn = (responses[5].data as Pagination<Album>).items as Album[];
-    const compilations = (responses[6].data as Pagination<Album>).items as Album[];
+    const allAlbums = (responses[3].data as Pagination<Album>).items as Album[];
+    const albums = allAlbums.filter((a) => a.album_type === 'album');
+    const singles = allAlbums.filter((a) => a.album_type === 'single');
+    const compilations = allAlbums.filter((a) => a.album_type === 'compilation');
+    const appearsOn: Album[] = [];
 
     const extraResponses = await Promise.all([
-      userService.checkSavedTracks(tracks.map((track) => track.id)).catch(() => ({ data: [] })),
+      tracks.length
+        ? userService.checkSavedTracks(tracks.map((track) => track.id)).catch(() => ({ data: [] }))
+        : Promise.resolve({ data: [] }),
     ]);
 
     const saved = extraResponses[0].data as boolean[];

--- a/src/store/slices/playlist.ts
+++ b/src/store/slices/playlist.ts
@@ -62,7 +62,9 @@ export const fetchPlaylist = createAsyncThunk<
   const canEdit = isMine || playlist.collaborative;
 
   const extraPromises = [
-    playlist.owner?.id ? userService.getUser(playlist.owner.id) : Promise.resolve({ data: null }),
+    // `/users/{id}` was removed Feb 2026, so we can't fetch the owner's full profile.
+    // The playlist already embeds its `owner` (id, display_name, uri) — use that for display.
+    Promise.resolve({ data: playlist.owner ?? null }),
     ids.length && user
       ? userService.checkSavedTracks(items.map((item) => item.track.id)).catch(() => ({ data: [] }))
       : Promise.resolve({ data: [] }),

--- a/src/store/slices/profile.ts
+++ b/src/store/slices/profile.ts
@@ -112,7 +112,9 @@ const fetchUser = createAsyncThunk<[User, Playlist[], boolean], string>(
     }
 
     const promises = [
-      userService.getUser(id),
+      // `/users/{id}` was removed Feb 2026. For the current user we already have the `/me`
+      // profile in auth; for other users it returns null and the page degrades gracefully.
+      user && user.id === id ? Promise.resolve({ data: user }) : userService.getUser(id),
       playlistService.getPlaylists(id, { limit: 10 }),
       user && user.id === id
         ? userService.checkFollowingUsers([id]).catch(() => {

--- a/src/store/slices/search.ts
+++ b/src/store/slices/search.ts
@@ -36,19 +36,19 @@ const initialState: {
 };
 
 const fetchArtists = createAsyncThunk<Artist[], string>('search/fetchArtists', async (query) => {
-  const response = await querySearch({ q: query, type: 'artist', limit: 50 });
+  const response = await querySearch({ q: query, type: 'artist', limit: 10 });
   return response.data.artists.items;
 });
 
 const fetchAlbums = createAsyncThunk<Album[], string>('search/fetchAlbums', async (query) => {
-  const response = await querySearch({ q: query, type: 'album', limit: 50 });
+  const response = await querySearch({ q: query, type: 'album', limit: 10 });
   return response.data.albums.items;
 });
 
 const fetchPlaylists = createAsyncThunk<Playlist[], string>(
   'search/fetchPlaylists',
   async (query) => {
-    const response = await querySearch({ q: query, type: 'playlist', limit: 50 });
+    const response = await querySearch({ q: query, type: 'playlist', limit: 10 });
     return response.data.playlists.items;
   }
 );
@@ -56,7 +56,7 @@ const fetchPlaylists = createAsyncThunk<Playlist[], string>(
 const fetchSongs = createAsyncThunk<[TrackWithSave[], number], string>(
   'search/fetchSongs',
   async (query, params) => {
-    const response = await querySearch({ q: query, type: 'track', limit: 50 });
+    const response = await querySearch({ q: query, type: 'track', limit: 10 });
     const tracks = response.data.tracks.items;
     const total = response.data.tracks.total;
 
@@ -87,7 +87,7 @@ const fetchMoreSongs = createAsyncThunk<TrackWithSave[], string>(
 
     const response = await querySearch({
       q: query,
-      limit: 50,
+      limit: 10,
       type: 'track',
       offset: songs.length,
     });

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,53 @@
+// Tiny IndexedDB key/value store used to cache Spotify GET responses across reloads and
+// across pages. Kept dependency-free and fully fault-tolerant: every operation swallows its
+// own errors (e.g. private-mode with IndexedDB disabled) so a cache failure never breaks a
+// request — callers just fall through to the network.
+
+const DB_NAME = 'spotify-api-cache';
+const STORE = 'responses';
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+const openDb = (): Promise<IDBDatabase> => {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => request.result.createObjectStore(STORE);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+  return dbPromise;
+};
+
+export interface CacheEntry<T = unknown> {
+  data: T;
+  expiry: number;
+}
+
+export const cacheGet = async <T>(key: string): Promise<CacheEntry<T> | undefined> => {
+  try {
+    const db = await openDb();
+    return await new Promise<CacheEntry<T> | undefined>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readonly');
+      const req = tx.objectStore(STORE).get(key);
+      req.onsuccess = () => resolve(req.result as CacheEntry<T> | undefined);
+      req.onerror = () => reject(req.error);
+    });
+  } catch {
+    return undefined;
+  }
+};
+
+export const cacheSet = async (key: string, entry: CacheEntry): Promise<void> => {
+  try {
+    const db = await openDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite');
+      tx.objectStore(STORE).put(entry, key);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } catch {
+    /* ignore — caching is best-effort */
+  }
+};

--- a/src/utils/spotify/login.ts
+++ b/src/utils/spotify/login.ts
@@ -10,7 +10,13 @@ const authUrl = new URL('https://accounts.spotify.com/authorize');
 
 const SCOPES = [
   'ugc-image-upload',
+
+  // Web Playback SDK: `streaming` only yields a playable device when the account-info
+  // scopes are also granted. Without these two the SDK registers a device that Spotify
+  // rejects as "Device not found" on playback. They are required, not optional.
   'streaming',
+  'user-read-email',
+  'user-read-private',
 
   'user-read-playback-state',
   'user-modify-playback-state',
@@ -53,12 +59,10 @@ const generateRandomString = (length: number) => {
 };
 
 const logInWithSpotify = async () => {
-  let codeVerifier = localStorage.getItem('code_verifier');
-
-  if (!codeVerifier) {
-    codeVerifier = generateRandomString(64);
-    localStorage.setItem('code_verifier', codeVerifier);
-  }
+  // Always mint a fresh verifier so the challenge sent to /authorize and the
+  // verifier sent to /api/token are guaranteed to be the same pair.
+  const codeVerifier = generateRandomString(64);
+  localStorage.setItem('code_verifier', codeVerifier);
 
   const hashed = await sha256(codeVerifier);
   const codeChallenge = base64encode(hashed);
@@ -75,35 +79,55 @@ const logInWithSpotify = async () => {
   window.location.href = authUrl.toString();
 };
 
+// An authorization code is single-use. React StrictMode mounts effects twice in
+// dev, which would exchange the same code twice (the second fails with
+// "Invalid authorization code"). Share one in-flight exchange per code.
+const inFlightExchanges: Record<string, Promise<string> | undefined> = {};
+
 const requestToken = async (code: string) => {
-  const code_verifier = localStorage.getItem('code_verifier') as string;
+  const existing = inFlightExchanges[code];
+  if (existing) return existing;
 
-  const body = {
-    code,
-    client_id,
-    redirect_uri,
-    code_verifier,
-    grant_type: 'authorization_code',
-  };
+  const exchange = (async () => {
+    const code_verifier = localStorage.getItem('code_verifier') as string;
 
-  const { data: response } = await Axios.post<{
-    access_token: string;
-    token_type: string;
-    expires_in: number;
-    refresh_token: string;
-  }>('https://accounts.spotify.com/api/token', body, {
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-  });
+    const body = {
+      code,
+      client_id,
+      redirect_uri,
+      code_verifier,
+      grant_type: 'authorization_code',
+    };
 
-  if (response.access_token) {
-    setLocalStorageWithExpiry('access_token', response.access_token, response.expires_in * 60 * 60);
-    axios.defaults.headers.common['Authorization'] = 'Bearer ' + response.access_token;
-    localStorage.setItem('refresh_token', response.refresh_token);
-  }
+    const { data: response } = await Axios.post<{
+      access_token: string;
+      token_type: string;
+      expires_in: number;
+      refresh_token: string;
+    }>('https://accounts.spotify.com/api/token', body, {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    });
 
-  return response.access_token;
+    if (response.access_token) {
+      setLocalStorageWithExpiry(
+        'access_token',
+        response.access_token,
+        response.expires_in * 60 * 60
+      );
+      axios.defaults.headers.common['Authorization'] = 'Bearer ' + response.access_token;
+      localStorage.setItem('refresh_token', response.refresh_token);
+      // Verifier is spent once the code is exchanged; clear it so a future login
+      // generates a fresh challenge/verifier pair.
+      localStorage.removeItem('code_verifier');
+    }
+
+    return response.access_token;
+  })();
+
+  inFlightExchanges[code] = exchange;
+  return exchange;
 };
 
 const getToken = async () => {
@@ -113,7 +137,12 @@ const getToken = async () => {
   const urlParams = new URLSearchParams(window.location.search);
 
   let code = urlParams.get('code') as string;
-  if (code) return [await requestToken(code), true];
+  if (code) {
+    // Strip ?code from the URL immediately so a reload can't re-exchange a
+    // spent authorization code.
+    window.history.replaceState({}, document.title, window.location.pathname);
+    return [await requestToken(code), true];
+  }
 
   return [null, false];
 };

--- a/src/utils/spotify/webPlayback.tsx
+++ b/src/utils/spotify/webPlayback.tsx
@@ -53,6 +53,10 @@ const WebPlayback: FC<WebPlaybackProps> = memo((props) => {
 
   const waitForDeviceToBeSelected = () => {
     return new Promise((resolve) => {
+      // Clear any prior poller first. Without this, every `null` state event (which happens
+      // during device transfers) stacked another no-delay interval, flooding the store with
+      // `setState` dispatches → "Maximum update depth exceeded".
+      if (deviceSelectedInterval.current) clearInterval(deviceSelectedInterval.current);
       deviceSelectedInterval.current = setInterval(() => {
         if (webPlaybackInstance.current) {
           webPlaybackInstance.current.getCurrentState().then((state) => {
@@ -63,11 +67,14 @@ const WebPlayback: FC<WebPlaybackProps> = memo((props) => {
             }
           });
         }
-      });
+      }, 1000);
     });
   };
 
   const startStatePolling = useCallback(() => {
+    // Guard against stacking multiple pollers, which would multiply the per-tick `setState`
+    // dispatches and can trigger "Maximum update depth exceeded".
+    if (statePollingInterval.current) clearInterval(statePollingInterval.current);
     statePollingInterval.current = setInterval(async () => {
       const state = await webPlaybackInstance.current!.getCurrentState();
       await handleState(state);
@@ -80,6 +87,9 @@ const WebPlayback: FC<WebPlaybackProps> = memo((props) => {
 
   const setupWebPlaybackEvents = useCallback(async () => {
     let { Player } = window.Spotify;
+    // Register the device name so playback can re-resolve the live device id by name when the
+    // SDK reconnects with a new id (otherwise play 404s with "Device not found").
+    playerService.setPlaybackDeviceName(playerName);
     webPlaybackInstance.current = new Player({
       name: playerName,
       enableMediaSession: true,
@@ -118,12 +128,44 @@ const WebPlayback: FC<WebPlaybackProps> = memo((props) => {
     webPlaybackInstance.current.on('ready', async (data) => {
       dispatch(spotifyActions.setDeviceId({ deviceId: data.device_id }));
       dispatch(spotifyActions.setActiveDevice({ activeDevice: data.device_id }));
-      await playerService.transferPlayback(data.device_id);
+      // Persist the live device id immediately (independently of the transfer below) so
+      // playback commands always carry it, even across hot-reloads.
+      playerService.setPlaybackDevice(data.device_id);
+      // The device takes a moment to register server-side after `ready`, so an immediate
+      // transfer often 404s ("Device not found"). Retry a few times with backoff. The id is
+      // already stored by transferPlayback, so play works even if transfer never succeeds.
+      for (let attempt = 0; attempt < 4; attempt++) {
+        try {
+          await playerService.transferPlayback(data.device_id);
+          break;
+        } catch (e) {
+          if (attempt === 3) {
+            console.warn('transferPlayback failed after retries:', e);
+          } else {
+            await new Promise((resolve) => setTimeout(resolve, 800));
+          }
+        }
+      }
     });
 
     if (playerAutoConnect) {
       webPlaybackInstance.current.connect();
       dispatch(spotifyActions.setPlayer({ player: webPlaybackInstance.current }));
+
+      // Browsers block audio until a user gesture. The Web Playback SDK exposes
+      // `activateElement()` for exactly this — call it once on the first interaction so the
+      // device can actually produce sound (otherwise playback silently fails).
+      const activateOnce = () => {
+        try {
+          (webPlaybackInstance.current as any)?.activateElement?.();
+        } catch {
+          /* no-op */
+        }
+        document.removeEventListener('click', activateOnce);
+        document.removeEventListener('keydown', activateOnce);
+      };
+      document.addEventListener('click', activateOnce);
+      document.addEventListener('keydown', activateOnce);
     }
   }, [
     playerName,


### PR DESCRIPTION
## Summary
Rewires the app for Spotify's Nov 2024 / Feb 2026 Web API changes and fixes
auth, playback, and rate-limiting issues surfaced along the way.

## Commits
- API endpoint migration (playlist items, /me/library, batch→individual, search limit, removed-endpoint degradation)
- PKCE auth hardening + Web Playback SDK scopes + fresh-token handling
- Web Playback device targeting, timer-leak fix, autoplay activation
- Request throttling + 429 backoff + StrictMode disable
- IndexedDB response cache for catalog GETs

## Test
Run on http://127.0.0.1:3000 with a Premium account: browse, open a
playlist/artist/album, like/follow, search, and play a track.