### PR TITLE
Update client for Spotify's Feb 2026 Web API + add an RTK Query data layerRtk query data layer

### DIFF
--- a/src/components/Lists/GridCards.tsx
+++ b/src/components/Lists/GridCards.tsx
@@ -165,9 +165,14 @@ export const PlaylistCard = ({
   const [t] = useTranslation(['playlist']);
 
   const title = item.name;
+  // Feb 2026 renamed the playlist track-count field `tracks` → `items`; fall back so we never
+  // render "undefined songs" regardless of which endpoint the playlist came from.
+  const trackTotal = (item as any).tracks?.total ?? (item as any).items?.total;
   const description = getDescription
     ? getDescription(item)
-    : item.tracks?.total + ' ' + t(item.tracks?.total === 1 ? 'song' : 'songs');
+    : trackTotal === undefined
+      ? ''
+      : trackTotal + ' ' + t(trackTotal === 1 ? 'song' : 'songs');
 
   return (
     <PlayistActionsWrapper playlist={item} trigger={['contextMenu']}>

--- a/src/pages/Album/index.tsx
+++ b/src/pages/Album/index.tsx
@@ -5,6 +5,7 @@ import { FC, RefObject, useEffect } from 'react';
 // Redux
 import { useAppDispatch } from '../../store/store';
 import { albumActions } from '../../store/slices/album';
+import { useGetAlbumPageQuery } from '../../store/endpoints/catalog';
 
 // Constants
 import AlbumPageContainer from './container';
@@ -14,12 +15,16 @@ const AlbumPage: FC<{ container: RefObject<HTMLDivElement | null> }> = (props) =
 
   const { albumId } = useParams<{ albumId: string }>();
 
+  // Cached/deduped via RTK Query; mirrored into the album slice for existing sub-components.
+  const { data: albumData } = useGetAlbumPageQuery(albumId!, { skip: !albumId });
+
   useEffect(() => {
-    if (albumId) dispatch(albumActions.fetchAlbum(albumId));
-    return () => {
+    if (albumData) {
+      dispatch(albumActions.setAlbumData(albumData));
+    } else {
       dispatch(albumActions.setAlbum({ album: null }));
-    };
-  }, [dispatch, albumId]);
+    }
+  }, [albumData, dispatch]);
 
   return <AlbumPageContainer container={props.container} />;
 };

--- a/src/pages/Artist/index.tsx
+++ b/src/pages/Artist/index.tsx
@@ -6,7 +6,8 @@ import { useParams } from 'react-router-dom';
 import { getImageAnalysis2 } from '../../utils/imageAnyliser';
 
 // Redux
-import { artistActions, fetchArtist } from '../../store/slices/artist';
+import { artistActions } from '../../store/slices/artist';
+import { useGetArtistPageQuery } from '../../store/endpoints/catalog';
 import { useAppDispatch, useAppSelector } from '../../store/store';
 
 import ArtistContent from './container/content';
@@ -26,15 +27,21 @@ export const ArtistPage: FC<ArtistPageProps> = memo((props) => {
   const params = useParams<{ artistId: string }>();
   const artist = useAppSelector((state) => state.artist.artist);
 
+  // Load via RTK Query (cached + deduped + revalidated). The result is mirrored into the artist
+  // slice so the existing sub-components keep reading state.artist.* unchanged. Revisiting an
+  // artist serves from cache with no network call.
+  const { data: artistData } = useGetArtistPageQuery(params.artistId!, {
+    skip: !params.artistId,
+  });
+
   useEffect(() => {
-    if (params.artistId) {
-      dispatch(fetchArtist(params.artistId));
-      dispatch(artistActions.fetchOtherArtists(params.artistId));
-    }
-    return () => {
+    if (artistData) {
+      dispatch(artistActions.setArtistData(artistData));
+    } else {
+      // New/uncached artist still loading — clear the mirror so we don't show the previous one.
       dispatch(artistActions.setArtist({ artist: null }));
-    };
-  }, [dispatch, params.artistId]);
+    }
+  }, [artistData, dispatch]);
 
   useEffect(() => {
     if (artist && artist.images?.length) {

--- a/src/pages/Playlist/index.tsx
+++ b/src/pages/Playlist/index.tsx
@@ -9,6 +9,7 @@ import { FC, RefObject, useEffect, useRef, useState } from 'react';
 
 // Redux
 import { playlistActions } from '../../store/slices/playlist';
+import { useGetPlaylistPageQuery } from '../../store/endpoints/catalog';
 import { useAppDispatch, useAppSelector } from '../../store/store';
 
 // Constants
@@ -35,14 +36,17 @@ const PlaylistView: FC<{ container: RefObject<HTMLDivElement | null> }> = (props
     }
   }, [playlist]);
 
+  // Cached/deduped via RTK Query (short TTL since playlists are mutable); mirrored into the
+  // playlist slice for existing sub-components. Pagination still uses getNextTracks.
+  const { data: playlistData } = useGetPlaylistPageQuery(playlistId!, { skip: !playlistId });
+
   useEffect(() => {
-    if (playlistId) {
-      dispatch(playlistActions.fetchPlaylist(playlistId));
-    }
-    return () => {
+    if (playlistData) {
+      dispatch(playlistActions.setPlaylistData(playlistData));
+    } else {
       dispatch(playlistActions.setPlaylist({ playlist: null }));
-    };
-  }, [dispatch, playlistId]);
+    }
+  }, [playlistData, dispatch]);
 
   if (!playlist) return null;
 

--- a/src/pages/User/Home/container/header.tsx
+++ b/src/pages/User/Home/container/header.tsx
@@ -49,9 +49,12 @@ export const UserHeader: FC<{ color: string }> = memo((props) => {
           </span>
 
           <div className='profile-header-details-container'>
-            <span data-encore-id='text'>
-              {user?.followers?.total || 0} {t('Followers')}
-            </span>
+            {/* `followers` was removed from GET /me in Feb 2026, so only show it when present. */}
+            {user?.followers?.total != null ? (
+              <span data-encore-id='text'>
+                {user.followers.total} {t('Followers')}
+              </span>
+            ) : null}
           </div>
         </div>
       </div>

--- a/src/services/artist.ts
+++ b/src/services/artist.ts
@@ -34,7 +34,12 @@ const fetchArtistAlbums = (
     /** @description The country for which the release date will be formatted. */
     market?: string;
   } = {}
-) => axios.get<Pagination<Album>>(`/artists/${id}/albums`, { params });
+) =>
+  // Feb 2026 reduced this endpoint's max `limit` from 50 to 10 (returns 400 "Invalid limit"
+  // otherwise). Clamp here so every caller is safe.
+  axios.get<Pagination<Album>>(`/artists/${id}/albums`, {
+    params: { ...params, limit: Math.min(params.limit ?? 10, 10) },
+  });
 
 /**
  * @description Get Spotify catalog information about an artist's top tracks by country.

--- a/src/services/playlists.ts
+++ b/src/services/playlists.ts
@@ -5,16 +5,21 @@ import type { Track } from '../interfaces/track';
 import type { Playlist, PlaylistItem } from '../interfaces/playlists';
 import type { Pagination, PaginationQueryParams } from '../interfaces/api';
 
+// Feb 2026 renamed the playlist object's track-count field `tracks` → `items` (both carry
+// `.total`). Backfill `tracks` from `items` so every component that reads `playlist.tracks.total`
+// (grid cards, header, sidebar) keeps working instead of showing "undefined songs".
+const normalizePlaylist = (p: any) => {
+  if (p && !p.tracks && p.items) p.tracks = p.items;
+  return p;
+};
+
 /**
  * @description Get a playlist owned by a Spotify user.
  * @param playlistId The Spotify ID for the playlist.
  */
 const getPlaylist = async (playlistId: string) => {
   const response = await axios.get<Playlist>(`/playlists/${playlistId}`);
-  // Feb 2026 may expose the playlist's track collection as `items` instead of `tracks`.
-  // Normalize to `tracks` so the header/table (which read `playlist.tracks.total`) are unchanged.
-  const data = response.data as unknown as Record<string, any>;
-  if (data && !data.tracks && data.items) data.tracks = data.items;
+  normalizePlaylist(response.data);
   return response;
 };
 
@@ -46,7 +51,9 @@ const getPlaylistItems = async (
  * @description Get a list of the playlists owned or followed by the current Spotify user.
  */
 const getMyPlaylists = async (params: PaginationQueryParams = {}) => {
-  return axios.get<Pagination<Playlist>>('/me/playlists', { params });
+  const response = await axios.get<Pagination<Playlist>>('/me/playlists', { params });
+  response.data?.items?.forEach(normalizePlaylist);
+  return response;
 };
 
 interface GetFeaturedPlaylistsParams extends PaginationQueryParams {
@@ -187,7 +194,9 @@ const getPlaylists = async (
 ) => {
   // Feb 2026 removed `/users/{id}/playlists` (other users). Only the current user's
   // playlists are available now, so this returns `/me/playlists` regardless of `_userId`.
-  return axios.get<Pagination<Playlist>>(`/me/playlists`, { params });
+  const response = await axios.get<Pagination<Playlist>>(`/me/playlists`, { params });
+  response.data?.items?.forEach(normalizePlaylist);
+  return response;
 };
 
 export const playlistService = {

--- a/src/store/api.ts
+++ b/src/store/api.ts
@@ -1,0 +1,48 @@
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
+
+// RTK Query data layer.
+//
+// Endpoints wrap the existing service functions (src/services/*) via `queryFn`, so they reuse the
+// axios transport — concurrency limiter, 429 backoff, auth/refresh, and the IndexedDB URL cache —
+// without re-implementing any endpoint logic. RTK Query adds request dedup, stale-while-
+// revalidate caching, and tag-based invalidation on top. Endpoints are injected per-domain via
+// `api.injectEndpoints` (see src/store/endpoints/*).
+
+export type ApiError = { status?: number; data?: unknown };
+
+// Standardizes turning a service call (which resolves to an axios-style `{ data }`) into the
+// `{ data } | { error }` shape RTK Query's queryFn expects.
+export const runQuery = async <T>(
+  fn: () => Promise<{ data: T }>
+): Promise<{ data: T } | { error: ApiError }> => {
+  try {
+    const res = await fn();
+    return { data: res.data };
+  } catch (e: any) {
+    return {
+      error: { status: e?.response?.status, data: e?.response?.data ?? e?.message } as ApiError,
+    };
+  }
+};
+
+export const api = createApi({
+  reducerPath: 'api',
+  baseQuery: fakeBaseQuery<ApiError>(),
+  tagTypes: [
+    'Artist',
+    'Album',
+    'Playlist',
+    'Track',
+    'Me',
+    'SavedTracks',
+    'SavedAlbums',
+    'FollowedArtists',
+    'MyPlaylists',
+    'Saved',
+  ],
+  // Catalog data dominates and is immutable, so default to a long cache lifetime; mutable
+  // endpoints override `keepUnusedDataFor` and opt into refetch-on-focus per hook.
+  keepUnusedDataFor: 60 * 60 * 24,
+  refetchOnReconnect: true,
+  endpoints: () => ({}),
+});

--- a/src/store/endpoints/catalog.ts
+++ b/src/store/endpoints/catalog.ts
@@ -1,0 +1,106 @@
+import { api, runQuery } from '../api';
+
+import { artistService } from '../../services/artist';
+import { userService } from '../../services/users';
+import { albumsService } from '../../services/albums';
+
+import type { RootState } from '../store';
+import type { Album, AlbumFullObject } from '../../interfaces/albums';
+import type { Track } from '../../interfaces/track';
+import type { ArtistPageData } from '../slices/artist';
+import type { AlbumPageData } from '../slices/album';
+
+// Catalog (mostly immutable) page queries. Each endpoint's queryFn composes the existing service
+// calls — identical to what the old page thunks did — so RTK Query adds caching/dedup/SWR on top
+// without re-implementing endpoint logic. Long `keepUnusedDataFor` (the api default) means
+// revisiting a page within the session does zero network calls.
+
+const catalogApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getArtistPage: build.query<ArtistPageData, string>({
+      async queryFn(id, { getState }) {
+        return runQuery(async () => {
+          const user = (getState() as RootState).auth.user;
+
+          const [artistRes, followingRes, topRes, albumsRes, otherRes] = await Promise.all([
+            artistService.fetchArtist(id),
+            user
+              ? userService.checkFollowingArtists([id])
+              : Promise.resolve({ data: [false] as boolean[] }),
+            artistService.fetchArtistTopTracks(id),
+            artistService.fetchArtistAlbums(id, {
+              limit: 50,
+              include_groups: 'album,single,appears_on,compilation' as any,
+            }),
+            artistService.fetchSimilarArtists(id),
+          ]);
+
+          const tracks = (topRes.data as any).tracks as Track[];
+          const saved = tracks.length
+            ? (
+                (await userService
+                  .checkSavedTracks(tracks.map((t) => t.id))
+                  .catch(() => ({ data: [] as boolean[] }))) as { data: boolean[] }
+              ).data
+            : [];
+
+          const all = (albumsRes.data.items as Album[]) ?? [];
+
+          return {
+            data: {
+              artist: artistRes.data,
+              following: (followingRes.data as boolean[])[0],
+              topTracks: tracks.map((t, i) => ({ ...t, saved: saved[i] })),
+              albums: all.filter((a) => a.album_type === 'album'),
+              singles: all.filter((a) => a.album_type === 'single'),
+              compilations: all.filter((a) => a.album_type === 'compilation'),
+              appearsOn: [],
+              otherArtists: otherRes.data.artists ?? [],
+            } satisfies ArtistPageData,
+          };
+        });
+      },
+      providesTags: (_res, _err, id) => [{ type: 'Artist', id }],
+    }),
+
+    getAlbumPage: build.query<AlbumPageData, string>({
+      async queryFn(id, { getState }) {
+        return runQuery(async () => {
+          const user = (getState() as RootState).auth.user;
+
+          const [albumRes, tracksRes, followingRes] = await Promise.all([
+            albumsService.fetchAlbum(id),
+            albumsService.fetchAlbumTracks(id, { limit: 50 }),
+            user
+              ? userService.checkFollowingArtists([id])
+              : Promise.resolve({ data: [false] as boolean[] }),
+          ]);
+
+          const album = albumRes.data as AlbumFullObject;
+          const items = (tracksRes.data.items as Track[]) ?? [];
+
+          const [savedRes, artistRes, otherRes] = await Promise.all([
+            userService.checkSavedTracks(items.map((t) => t.id)).catch(() => ({ data: [] as boolean[] })),
+            artistService.fetchArtist(album.artists[0].id),
+            artistService.fetchArtistAlbums(album.artists[0].id, { limit: 10 }),
+          ]);
+
+          const saved = savedRes.data as boolean[];
+
+          return {
+            data: {
+              album,
+              tracks: items.map((t, i) => ({ ...t, saved: saved[i] })),
+              following: (followingRes.data as boolean[])[0],
+              artist: artistRes.data,
+              otherAlbums: (otherRes.data.items as Album[]) ?? [],
+            } satisfies AlbumPageData,
+          };
+        });
+      },
+      providesTags: (_res, _err, id) => [{ type: 'Album', id }],
+    }),
+  }),
+});
+
+export const { useGetArtistPageQuery, useGetAlbumPageQuery } = catalogApi;

--- a/src/store/endpoints/catalog.ts
+++ b/src/store/endpoints/catalog.ts
@@ -112,7 +112,12 @@ const catalogApi = api.injectEndpoints({
 
           const [plRes, itemsRes, followingRes] = await Promise.all([
             playlistService.getPlaylist(id),
-            playlistService.getPlaylistItems(id),
+            // Feb 2026: GET /playlists/{id}/items is owner/collaborator-only — it 403s for
+            // editorial/other-users' playlists. Degrade to an empty track list (metadata from
+            // getPlaylist still renders) instead of failing the whole page.
+            playlistService
+              .getPlaylistItems(id)
+              .catch(() => ({ data: { items: [] as PlaylistItem[] } as any })),
             user
               ? userService.checkFollowedPlaylist(id)
               : Promise.resolve({ data: [false] as boolean[] }),

--- a/src/store/endpoints/catalog.ts
+++ b/src/store/endpoints/catalog.ts
@@ -3,12 +3,16 @@ import { api, runQuery } from '../api';
 import { artistService } from '../../services/artist';
 import { userService } from '../../services/users';
 import { albumsService } from '../../services/albums';
+import { playlistService } from '../../services/playlists';
 
 import type { RootState } from '../store';
 import type { Album, AlbumFullObject } from '../../interfaces/albums';
 import type { Track } from '../../interfaces/track';
+import type { User } from '../../interfaces/user';
+import type { Playlist, PlaylistItem } from '../../interfaces/playlists';
 import type { ArtistPageData } from '../slices/artist';
 import type { AlbumPageData } from '../slices/album';
+import type { PlaylistPageData } from '../slices/playlist';
 
 // Catalog (mostly immutable) page queries. Each endpoint's queryFn composes the existing service
 // calls — identical to what the old page thunks did — so RTK Query adds caching/dedup/SWR on top
@@ -100,7 +104,65 @@ const catalogApi = api.injectEndpoints({
       },
       providesTags: (_res, _err, id) => [{ type: 'Album', id }],
     }),
+
+    getPlaylistPage: build.query<PlaylistPageData, string>({
+      async queryFn(id, { getState }) {
+        return runQuery(async () => {
+          const user = (getState() as RootState).auth.user;
+
+          const [plRes, itemsRes, followingRes] = await Promise.all([
+            playlistService.getPlaylist(id),
+            playlistService.getPlaylistItems(id),
+            user
+              ? userService.checkFollowedPlaylist(id)
+              : Promise.resolve({ data: [false] as boolean[] }),
+          ]);
+
+          const playlist = plRes.data as Playlist;
+          const items = (itemsRes.data.items as PlaylistItem[]) ?? [];
+          const ids = items.map((i) => i.track.id);
+          const artistsIds = items.map((i) => i.track.artists[0].id);
+          const isMine = user?.id === playlist.owner?.id;
+
+          const [savedRes, recRes] = await Promise.all([
+            ids.length && user
+              ? userService.checkSavedTracks(ids).catch(() => ({ data: [] as boolean[] }))
+              : Promise.resolve({ data: [] as boolean[] }),
+            isMine
+              ? ids.length
+                ? playlistService
+                    .getRecommendations({
+                      seed_tracks: ids.slice(0, 5).join(',') || undefined,
+                      seed_artists: artistsIds.slice(0, 5).join(',') || undefined,
+                      limit: 25,
+                    })
+                    .then((r) => ({ data: r.data.tracks }))
+                    .catch(() => ({ data: [] as Track[] }))
+                : userService
+                    .fetchTopTracks({ limit: 25, timeRange: 'short_term' })
+                    .then((r) => ({ data: r.data.items as Track[] }))
+              : Promise.resolve({ data: [] as Track[] }),
+          ]);
+
+          const saved = savedRes.data as boolean[];
+
+          return {
+            data: {
+              playlist,
+              tracks: items.map((item, i) => ({ ...item, saved: saved[i] })),
+              following: (followingRes.data as boolean[])[0],
+              canEdit: isMine || playlist.collaborative,
+              user: (playlist.owner ?? null) as User | null,
+              recommendations: recRes.data as Track[],
+            } satisfies PlaylistPageData,
+          };
+        });
+      },
+      // Playlists are mutable (edits/follow), so keep a short cache and revalidate.
+      keepUnusedDataFor: 120,
+      providesTags: (_res, _err, id) => [{ type: 'Playlist', id }],
+    }),
   }),
 });
 
-export const { useGetArtistPageQuery, useGetAlbumPageQuery } = catalogApi;
+export const { useGetArtistPageQuery, useGetAlbumPageQuery, useGetPlaylistPageQuery } = catalogApi;

--- a/src/store/slices/album.ts
+++ b/src/store/slices/album.ts
@@ -12,6 +12,16 @@ import type { Artist } from '../../interfaces/artist';
 import type { Track, TrackWithSave } from '../../interfaces/track';
 import { RootState } from '../store';
 
+// Shape produced by the RTK Query `getAlbumPage` endpoint, mirrored into this slice so existing
+// Album sub-components keep reading state.album.* unchanged.
+export interface AlbumPageData {
+  album: AlbumFullObject;
+  tracks: TrackWithSave[];
+  following: boolean;
+  artist: Artist;
+  otherAlbums: Album[];
+}
+
 const initialState: {
   artist: Artist | null;
   tracks: TrackWithSave[];
@@ -105,6 +115,16 @@ const albumSlice = createSlice({
     },
     resetOrder(state, action: PayloadAction<{ order?: string }>) {
       state.order = action.payload.order || 'ALL';
+    },
+    // Mirror an RTK Query `getAlbumPage` result into this slice.
+    setAlbumData(state, action: PayloadAction<AlbumPageData>) {
+      const p = action.payload;
+      state.album = p.album;
+      state.tracks = p.tracks;
+      state.artist = p.artist;
+      state.following = p.following;
+      state.otherAlbums = p.otherAlbums;
+      state.loading = false;
     },
   },
   extraReducers: (builder) => {

--- a/src/store/slices/artist.ts
+++ b/src/store/slices/artist.ts
@@ -11,6 +11,19 @@ import type { Artist } from '../../interfaces/artist';
 import type { Track, TrackWithSave } from '../../interfaces/track';
 import { RootState } from '../store';
 
+// Shape produced by the RTK Query `getArtistPage` endpoint and mirrored into this slice so the
+// existing Artist sub-components (which read state.artist.*) keep working unchanged.
+export interface ArtistPageData {
+  artist: Artist;
+  following: boolean;
+  topTracks: TrackWithSave[];
+  albums: Album[];
+  singles: Album[];
+  appearsOn: Album[];
+  compilations: Album[];
+  otherArtists: Artist[];
+}
+
 const initialState: {
   albums: Album[];
   singles: Album[];
@@ -119,6 +132,20 @@ const artistSlice = createSlice({
       state.topTracks = state.topTracks.map((track) =>
         track.id === action.payload.id ? { ...track, saved: action.payload.saved } : track
       );
+    },
+    // Mirror an RTK Query `getArtistPage` result into this slice (the page is now loaded via
+    // RTK Query for caching/dedup; the slice stays a view mirror for existing components).
+    setArtistData(state, action: PayloadAction<ArtistPageData>) {
+      const p = action.payload;
+      state.artist = p.artist;
+      state.following = p.following;
+      state.topTracks = p.topTracks;
+      state.albums = p.albums;
+      state.singles = p.singles;
+      state.appearsOn = p.appearsOn;
+      state.compilations = p.compilations;
+      state.otherArtists = p.otherArtists;
+      state.loading = false;
     },
   },
   extraReducers: (builder) => {

--- a/src/store/slices/discography.ts
+++ b/src/store/slices/discography.ts
@@ -29,19 +29,21 @@ const initialState: {
 const fetchData = createAsyncThunk<[Artist, Album[][]], string>(
   'discography/fetchData',
   async (id) => {
-    const promises = [
+    // One combined `/artists/{id}/albums` request instead of four (Spotify rate-limits this
+    // endpoint hard, per-endpoint), partitioned client-side by album_type.
+    const [artistRes, albumsRes] = await Promise.all([
       artistService.fetchArtist(id),
-      artistService.fetchArtistAlbums(id, { limit: 50, include_groups: 'album' }),
-      artistService.fetchArtistAlbums(id, { limit: 50, include_groups: 'single' }),
-      artistService.fetchArtistAlbums(id, { limit: 50, include_groups: 'compilation' }),
-    ];
+      artistService.fetchArtistAlbums(id, {
+        limit: 50,
+        include_groups: 'album,single,compilation' as any,
+      }),
+    ]);
 
-    const responses = await Promise.all(promises);
-
-    const artist = responses[0].data as Artist;
-    const albums = (responses[1].data as Pagination<Album>).items as Album[];
-    const singles = (responses[2].data as Pagination<Album>).items as Album[];
-    const compilations = (responses[3].data as Pagination<Album>).items as Album[];
+    const artist = artistRes.data as Artist;
+    const all = ((albumsRes.data as Pagination<Album>).items as Album[]) ?? [];
+    const albums = all.filter((a) => a.album_type === 'album');
+    const singles = all.filter((a) => a.album_type === 'single');
+    const compilations = all.filter((a) => a.album_type === 'compilation');
 
     return [artist, [albums, singles, compilations]];
   }

--- a/src/store/slices/home.ts
+++ b/src/store/slices/home.ts
@@ -19,7 +19,7 @@ import { searchEpisodes } from '../../services/search';
 import { fetchMoreLikeArtistItems } from '../../pages/Home/utils/fetchMoreLikeArtistItems';
 
 // Utils
-import { groupBy, shuffle, uniq, uniqBy } from 'lodash';
+import { groupBy, uniq, uniqBy } from 'lodash';
 
 // Constants
 import {
@@ -35,10 +35,6 @@ export interface MoreLikeArtistSection {
   items: Awaited<ReturnType<typeof fetchMoreLikeArtistItems>>;
 }
 
-// Each "More like {artist}" row costs ~2 requests (a playlist search + the artist's albums).
-// Kept low to stay well under Spotify's rate limit on a cold Home load; RTK Query dedups/caches
-// them so repeat loads are free.
-const MORE_LIKE_ARTISTS_LIMIT = 2;
 
 const initialState: {
   topTracks: Track[];
@@ -190,36 +186,15 @@ export const fetchPodcastEpisodes = createAsyncThunk('home/fetchPodcastEpisodes'
   return pickUniqueEpisodes([mightLikePool, toTryPool, combinedFallback], 1);
 });
 
-export const fetchMoreLikeArtists = createAsyncThunk(
-  'home/fetchMoreLikeArtists',
-  async (_, { getState }) => {
-    const state = getState() as RootState;
-    let artists = state.yourLibrary.myArtists;
-
-    if (!artists.length) {
-      try {
-        const response = await userService.fetchFollowedArtists({ limit: 50 });
-        artists = response.data.artists.items;
-      } catch {
-        return [];
-      }
-    }
-
-    const pickedArtists = shuffle(artists).slice(0, MORE_LIKE_ARTISTS_LIMIT);
-    if (!pickedArtists.length) {
-      return [];
-    }
-
-    const sections = await Promise.all(
-      pickedArtists.map(async (artist) => {
-        const items = await fetchMoreLikeArtistItems(artist);
-        return { artist, items };
-      }),
-    );
-
-    return sections.filter((section) => section.items.length > 0);
-  },
-);
+export const fetchMoreLikeArtists = createAsyncThunk('home/fetchMoreLikeArtists', async () => {
+  // Disabled. This fanned out `GET /artists/{id}/albums` per followed artist on EVERY Home load,
+  // which Spotify rate-limits *per endpoint* — that single endpoint was being driven into a 429
+  // cooldown while every other endpoint stayed healthy. The section was already degraded anyway
+  // (related-artists was removed from the API in Nov 2024 / Feb 2026, so it only showed the
+  // artist's own albums + name-matched playlists). Returning [] stops the hammering and lets the
+  // endpoint's rate-limit window recover. Re-enable via fetchMoreLikeArtistItems if quota allows.
+  return [];
+});
 
 export const fecthFeaturedPlaylists = createAsyncThunk(
   'home/fecthFeaturedPlaylists',

--- a/src/store/slices/home.ts
+++ b/src/store/slices/home.ts
@@ -35,7 +35,10 @@ export interface MoreLikeArtistSection {
   items: Awaited<ReturnType<typeof fetchMoreLikeArtistItems>>;
 }
 
-const MORE_LIKE_ARTISTS_LIMIT = 4;
+// Each "More like {artist}" row costs ~2 requests (a playlist search + the artist's albums).
+// Kept low to stay well under Spotify's rate limit on a cold Home load; RTK Query dedups/caches
+// them so repeat loads are free.
+const MORE_LIKE_ARTISTS_LIMIT = 2;
 
 const initialState: {
   topTracks: Track[];
@@ -104,8 +107,11 @@ export const fetchRecentlyPlayed = createAsyncThunk('home/fetchRecentlyPlayed', 
     const artistsTracks = groupedItems['artist'] || [];
     const albumsTracks = groupedItems['album'] || [];
 
-    const artistsIds = uniq(artistsTracks.map((item) => item.context.uri.split(':')[2]));
-    const albumsIds = uniq(albumsTracks.map((item) => item.context.uri.split(':')[2]));
+    // Cap how many ids we resolve: batch endpoints were removed (Feb 2026), so each id is now an
+    // individual GET. Resolving every unique id from 50 recently-played items could fire dozens of
+    // requests and trip the rate limit; the row only shows a handful, so 8 each is plenty.
+    const artistsIds = uniq(artistsTracks.map((item) => item.context.uri.split(':')[2])).slice(0, 8);
+    const albumsIds = uniq(albumsTracks.map((item) => item.context.uri.split(':')[2])).slice(0, 8);
 
     const promises = [
       artistsIds.length

--- a/src/store/slices/playlist.ts
+++ b/src/store/slices/playlist.ts
@@ -11,6 +11,17 @@ import type { Track } from '../../interfaces/track';
 import type { Pagination } from '../../interfaces/api';
 import type { Playlist, PlaylistItem, PlaylistItemWithSaved } from '../../interfaces/playlists';
 
+// Shape produced by the RTK Query `getPlaylistPage` endpoint, mirrored into this slice so the
+// existing Playlist sub-components keep reading state.playlist.* unchanged.
+export interface PlaylistPageData {
+  playlist: Playlist;
+  tracks: PlaylistItemWithSaved[];
+  following: boolean;
+  canEdit: boolean;
+  user: User | null;
+  recommendations: Track[];
+}
+
 const initialState: {
   user: User | null;
   recommedations: Track[];
@@ -199,6 +210,17 @@ const playlistSlice = createSlice({
     },
     removeTrackFromRecommendations(state, action: PayloadAction<{ id: string }>) {
       state.recommedations = state.recommedations.filter((track) => track.id !== action.payload.id);
+    },
+    // Mirror an RTK Query `getPlaylistPage` result into this slice.
+    setPlaylistData(state, action: PayloadAction<PlaylistPageData>) {
+      const p = action.payload;
+      state.playlist = p.playlist;
+      state.tracks = p.tracks;
+      state.following = p.following;
+      state.canEdit = p.canEdit;
+      state.user = p.user;
+      state.recommedations = p.recommendations;
+      state.loading = false;
     },
   },
   extraReducers: (builder) => {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -9,8 +9,12 @@ import {
   persistReducer,
 } from 'redux-persist';
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import { setupListeners } from '@reduxjs/toolkit/query';
 import storage from 'redux-persist/lib/storage'; // defaults to localStorage
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+
+// RTK Query data layer
+import { api } from './api';
 
 // Reducers
 import uiReducer from './slices/ui';
@@ -54,6 +58,7 @@ const appReducer = combineReducers({
   searchHistory: searchHistoryReducer,
   artistDiscography: artistDiscographyReducer,
   editPlaylistModal: editPlaylistModalReducer,
+  [api.reducerPath]: api.reducer,
 });
 
 // @ts-ignore
@@ -84,8 +89,11 @@ export const store = configureStore({
         ignoredPaths: ['spotify.player'],
         ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
       },
-    }),
+    }).concat(api.middleware),
 });
+
+// Enable refetchOnFocus / refetchOnReconnect behavior for RTK Query.
+setupListeners(store.dispatch);
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## Summary
Spotify's November 2024 and February 2026 Web API changes removed/renamed many endpoints and fields and tightened rate limits, which broke this client (404s, 400s, 403s, 429s, and "undefined" values in the UI). This PR adds additional patches necessary for migrating the app to the current API and adds a caching data layer so it stays under the new rate limits.

## API migration (Nov 2024 / Feb 2026)
- Playlist items: `/playlists/{id}/tracks` → `/playlists/{id}/items` (+ remap `items[].item` → `track`); the items endpoint is now owner/collaborator-only, so non-owned playlists degrade gracefully (header renders, empty track list).
- Library consolidation: per-type save/like/follow + `contains` → `/me/library`.
- Batch fetches removed → individual `GET /{id}` via `Promise.all`.
- Reduced `limit` caps honored: `/search` and `/artists/{id}/albums` max is now 10 (clamped to avoid `400 Invalid limit`).
- Removed-with-no-replacement endpoints degrade cleanly: browse/featured/categories, artist top-tracks & related-artists, recommendations, other-user profiles.
- Field renames/removals handled: playlist `tracks` → `items` (fixed "undefined songs"); `followers`/`popularity`/`product` removed — guarded or hidden where read.

## Auth & playback
- PKCE hardening: fresh verifier per login, single-use auth-code exchange (no StrictMode/reload double-exchange), URL `?code` cleanup.
- Added the Web Playback SDK's required scopes (`user-read-email`, `user-read-private`) and hand the SDK a fresh token (fixes 401s on the SDK's `check_scope` call).
- Reliable playback: target the SDK device explicitly (resolve live by name), retry the eager transfer, call `activateElement()` for autoplay, and fix an interval leak that caused "Maximum update depth exceeded".

## Rate-limit resilience + caching

The Feb 2026 changes tightened rate limits and — as this work uncovered — Spotify throttles **per endpoint**, not just per app. The client fetched far too aggressively (per-page blob thunks that refetched on every navigation, no dedup, no cache), so it constantly hit `429`. This adds three composable layers, transport-first:

**Transport layer ([src/axios.ts](src/axios.ts))**
- Global concurrency limiter: at most 3 requests in flight at once; the rest queue and drain as slots free, so request-heavy screens can't burst past the limit.
- `429` backoff: on a rate-limit response, wait (honoring `Retry-After` when present) and retry — bounded to a single retry so a cooldown isn't amplified by repeated re-issues.
- These wrap every request, including the ones RTK Query makes.

**Persistence layer ([src/utils/cache.ts](src/utils/cache.ts))**
- IndexedDB response cache for immutable catalog GETs (`/artists`, `/albums`, `/tracks`), keyed by URL + params with a 24h TTL.
- Cache hits are served via a one-off axios adapter (no network request at all), so catalog data survives hard reloads and is shared across pages.

**Data layer — RTK Query ([src/store/api.ts](src/store/api.ts), [src/store/endpoints/catalog.ts](src/store/endpoints/catalog.ts))**
- `createApi` with `fakeBaseQuery`; each endpoint's `queryFn` wraps the existing service functions, so it inherits the transport + IndexedDB layers above with zero duplicated endpoint logic.
- Composite per-page queries (`getArtistPage` / `getAlbumPage` / `getPlaylistPage`) run the same service calls the old page thunks did, then mirror the result into the existing slices — so the page sub-components keep reading `state.*` unchanged (incremental, low-risk migration).
- The per-page unmount state-wipes are removed, so revisiting a page within `keepUnusedDataFor` makes **zero** network calls, and concurrent components requesting the same id **dedup** to one request.
- Freshness policy: immutable catalog uses a 24h cache lifetime; mutable playlists use a short TTL; `refetchOnReconnect` is enabled. Tag types are defined for future mutation-driven invalidation.

**Cutting the per-endpoint hot spot (`/artists/{id}/albums`)**
- Diagnosis: this endpoint returned `429` on every call while sibling endpoints (`/artists/{id}`, `/me`, `/search`) returned `200` for the same token — i.e. it was individually throttled because the app called it far more than anything else.
- Removed the biggest repeat caller: the Home "more-like-artists" rows fanned out `/artists/{id}/albums` per followed artist on every Home load. The feature was already degraded (related-artists was removed from the API), so it's disabled rather than kept hammering the endpoint.
- Combined the Discography page's 4 per-`include_group` album calls into 1 (partitioned client-side by `album_type`), matching the artist page.
- Also removed the new-releases per-artist burst and capped the recently-played artist/album enrichment (batch endpoints were removed, so each id is now an individual GET).
- Net: `/artists/{id}/albums` is touched rarely (one cached call per artist/album page) instead of dozens per Home load, letting its rate-limit window recover.

**Dev note**
- React `StrictMode` is disabled: in development it double-invokes effects, firing every API request twice — a major contributor to tripping the rate limit while testing.

## Testing
- `tsc --noEmit` and a production build pass.
- Manual: run on `http://127.0.0.1:3000` with a Premium account — browse, open Artist/Album/Playlist (revisit = no refetch), like/follow, search, and play.

## Notes / out of scope
- Some list endpoints still request `limit: 50`; if Spotify reduced their caps too, they'd return `400 Invalid limit` and need the same clamp.
- A few features have no first-party replacement post-2026 (real related-artists, recommendations, browse) and are intentionally hidden/approximated.
